### PR TITLE
Fix an error with errorCode not being defined so it was throwing a 500 error

### DIFF
--- a/lib/models/registration_response.ex
+++ b/lib/models/registration_response.ex
@@ -69,7 +69,7 @@ defmodule U2FEx.RegistrationResponse do
   def from_json(json_input) when is_binary(json_input) do
     case Jason.decode(json_input) do
       {:ok, decoded} ->
-        do_from_json(decoded["registrationData"])
+        do_from_json(decoded)
 
       {:error, %Jason.DecodeError{}} ->
         {:error, :invalid_json}
@@ -77,13 +77,13 @@ defmodule U2FEx.RegistrationResponse do
   end
 
   @spec do_from_json(map()) :: {:ok, __MODULE__.t()} | {:error, :u2f}
-  defp do_from_json(%{"errorCode" => error}), do: Errors.get_retval_from_error(error)
-
-  defp do_from_json(registration_data) do
+  defp do_from_json(%{"registrationData" => registration_data}) do
     registration_data
     |> Utils.b64_decode()
     |> from_binary()
   end
+
+  defp do_from_json(%{"errorCode" => error}), do: Errors.get_retval_from_error(error)
 
   @doc """
   Exports a RegistrationResponse -> KeyMetadata for finishing registration on consumer applications side.

--- a/lib/models/registration_response.ex
+++ b/lib/models/registration_response.ex
@@ -69,7 +69,7 @@ defmodule U2FEx.RegistrationResponse do
   def from_json(json_input) when is_binary(json_input) do
     case Jason.decode(json_input) do
       {:ok, decoded} ->
-        do_from_json(decoded)
+        do_from_json(decoded["registrationData"])
 
       {:error, %Jason.DecodeError{}} ->
         {:error, :invalid_json}
@@ -79,7 +79,7 @@ defmodule U2FEx.RegistrationResponse do
   @spec do_from_json(map()) :: {:ok, __MODULE__.t()} | {:error, :u2f}
   defp do_from_json(%{"errorCode" => error}), do: Errors.get_retval_from_error(error)
 
-  defp do_from_json(%{"registrationData" => registration_data}) do
+  defp do_from_json(registration_data) do
     registration_data
     |> Utils.b64_decode()
     |> from_binary()

--- a/lib/models/sign_response.ex
+++ b/lib/models/sign_response.ex
@@ -110,8 +110,6 @@ defmodule U2FEx.SignResponse do
              | :u2f_configuration_unsupported
              | :u2f_device_ineligible
              | :u2f_timeout}
-  defp do_from_json(%{"errorCode" => error}), do: Errors.get_retval_from_error(error)
-
   defp do_from_json(%{
          "signatureData" => s,
          "clientData" => c,
@@ -122,4 +120,7 @@ defmodule U2FEx.SignResponse do
     key_handle = Utils.b64_decode(k)
     from_binary(key_handle, client_data, signature_data)
   end
+
+  defp do_from_json(%{"errorCode" => error}), do: Errors.get_retval_from_error(error)
+
 end


### PR DESCRIPTION
I was having an error with this particular part of the code. 

```
[error] #PID<0.609.0> running ExampleWeb.Endpoint (connection 
#PID<0.592.0>, stream id 27) terminated
Server: localhost:4000 (https)
Request: POST /u2f/finish_registration
** (exit) an exception was raised:
    ** (CaseClauseError) no case clause matching: 0
        (u2f_ex) lib/models/errors.ex:11: U2FEx.Errors.get_retval_from_error/1
        (u2f_ex) lib/u2f_ex.ex:70: U2FEx.finish_registration/2        (example) lib/example_web/controllers/u2f_controller.ex:30: ExampleWeb.U2FController.finish_registration/2
```

Changing the order of these functions fixes the problem. 